### PR TITLE
chore(k8s): migrate ingress to gateway

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ importer-module.docker.env
 mapping-module.docker.env
 db_backup/
 kong_data/
+/.idea/

--- a/helm-chart/gateway-chart/Chart.yaml
+++ b/helm-chart/gateway-chart/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+name: gateway-chart
+description: A Helm chart for Kubernetes
+version: 0.0.1

--- a/helm-chart/gateway-chart/templates/gateway.yaml
+++ b/helm-chart/gateway-chart/templates/gateway.yaml
@@ -1,0 +1,50 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: sdk-gateway
+spec:
+  gatewayClassName: nginx
+  listeners:
+    - protocol: HTTP
+      port: 80
+      name: http
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: mapping-route
+spec:
+  parentRefs:
+    - name: sdk-gateway
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /sdk/mapping
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplacePrefixMatch
+              replacePrefixMatch: /
+      backendRefs:
+        - name: mapping-module
+          port: 3001
+          kind: Service
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: importer-route
+spec:
+  parentRefs:
+    - name: sdk-gateway
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: importer-module
+          port: 3000
+          kind: Service

--- a/helm-chart/importer-chart/templates/importer-module-docker-env-configmap.yaml
+++ b/helm-chart/importer-chart/templates/importer-module-docker-env-configmap.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 data:
-  IMPORTER_DB_HOST: mongodb://mongo.ingress-nginx.svc.cluster.local:27018
+  IMPORTER_DB_HOST: mongodb://mongo.nginx-gateway.svc.cluster.local:27018
   IMPORTER_DB_NAME: nuvo
   IMPORTER_DB_PASSWORD: nuvo
   IMPORTER_DB_USERNAME: nuvo


### PR DESCRIPTION
## Setting up LocalStack via Helm Chart

This guide will help you set up and deploy services locally using Helm charts on Kubernetes with Minikube. It simplifies the process of testing and managing your services.

### Prerequisites

Ensure the following tools are installed and configured:

- Docker
- Kubernetes (v1.31.4 or later)
- Minikube
- Helm

### Setup Process

1. Start Minikube

First, start the Minikube server to set up the Kubernetes cluster:

```bash
minikube start
```

2. Install NGINX Gateway Fabric

To install the latest stable release of NGINX Gateway Fabric in the nginx-gateway namespace, run the following command

```bash
kubectl kustomize "https://github.com/nginxinc/nginx-gateway-fabric/config/crd/gateway-api/standard?ref=v1.6.2" | kubectl apply -f -

helm install ngf oci://ghcr.io/nginx/charts/nginx-gateway-fabric --create-namespace -n nginx-gateway
```

3. Login to Docker Registry

Before installing services, log in to the Docker registry. Replace `{username}` and `{password}` with your Docker Hub credentials.

```bash
kubectl create secret docker-registry -n nginx-gateway my-dockerhub-secret \
  --docker-server=https://index.docker.io/v1/ \
  --docker-username={username} \
  --docker-password={password} \
  --docker-email=-
```

4. Install the Services

1. Install Importer and Mapping Services

After the ingress controller is set up, you can install the services:

```bash
helm install importer ./helm-chart/importer-chart -n nginx-gateway

helm install mapping ./helm-chart/mapping-chart -n nginx-gateway

helm install sdk-gateway ./helm-chart/gateway-chart -n nginx-gateway
```

5. Check the Service Status

After installing, verify that all the pods are running. You should see the following services in `Running` status:

```bash
 kubectl get pod -n nginx-gateway
```

The expected services are:

1. `ngf-nginx-gateway-fabric`
2. `importer-module`
3. `mapping-module`
4. `mongo`

If any pod fails to start, you can troubleshoot using:

```bash
kubectl describe pod <pod_name> -n nginx-gateway
```

6. Port Forwarding

To access the services locally, you have two options:

**Option 1: Using** kubectl port-forward

You can forward the port to access the services locally. You can change 8000 to any port you prefer:

```bash
kubectl port-forward --namespace=nginx-gateway service/ngf-nginx-gateway-fabric 8080:80
```

Once the port is forwarded, you can access the services via http://localhost:8000.

**Option 2: Using** minikube tunnel (Recommended)

Alternatively, you can use minikube tunnel to create routes to your services in the Minikube cluster. This method doesn't require manually forwarding individual ports:

1. Start the minikube tunnel:

```bash
minikube tunnel
```

2. After running the tunnel, your services will be accessible through localhost without the need to specify ports for each service.

The nginx-ingress-controller will be available at http://localhost:80.
You can access your services through their defined paths (e.g., http://localhost/sdk/v1/...).

## Conclusion

This repository provides comprehensive instructions for setting up a local development environment using both Docker Compose and Kubernetes. For services running with Docker Compose, Kong is used as the API Gateway to manage and route traffic. For Kubernetes-based deployments, Helm charts and the NGINX Ingress Controller are used for service management and routing.